### PR TITLE
Add constraints to continue records development

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The ultimate goal is to provide these features:
   - [x] Kinds
   - [x] GADTs
   - [x] Equational pattern matching
-  - [ ] Type constraints
+  - [x] Type constraints
   - [ ] Records
   - [ ] Row polymorphism
   - [ ] Type classes and instances

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The ultimate goal is to provide these features:
   - [x] Kinds
   - [x] GADTs
   - [x] Equational pattern matching
+  - [ ] Type constraints
   - [ ] Records
   - [ ] Row polymorphism
   - [ ] Type classes and instances
@@ -68,12 +69,11 @@ Nihil natively supports some unicode equivalents to ASCII characters:
 
 | ASCII  | Unicode |
 |:------:|:-------:|
-| `->`   |    `→`  |
+| `->`   |   `→`   |
 | `=>`   |   `⇒`   |
+| `~`    |   `∼`   |
 | `\`    |   `λ`   |
 <!-- |`forall`|  `∀`    | -->
-| `{{`   |  `⦃`    |
-| `}}`   |  `⦄`    |
 
 ## <a name='Examples'></a>Examples
 

--- a/src/Nihil/Syntax.hs
+++ b/src/Nihil/Syntax.hs
@@ -34,7 +34,9 @@ runDesugarer p = runExcept (evalStateT (desugar p) defaultOperators)
         defaultOperators = DState defaultTOps defaultVOps defaultPOps
 
         defaultTOps = Map.fromList
-            [ ("->", (CC.R, 0)), ("→", (CC.R, 0)) ]
+            [ ("->", (CC.R, -1)), ("→", (CC.R, -1))
+            , ("=>", (CC.R, -1)), ("̄̄⇒", (CC.R, -1))
+            , ("~", (CC.L, 0)),   ("∼", (CC.L, 0))  ]
         defaultVOps = Map.fromList
             [ ("*", (CC.L, 7)), ("/", (CC.L, 7))
             , ("+", (CC.L, 6)), ("-", (CC.L, 6))

--- a/src/Nihil/Syntax/Concrete/Parser/Identifier.hs
+++ b/src/Nihil/Syntax/Concrete/Parser/Identifier.hs
@@ -121,4 +121,4 @@ reservedExpressionOperators :: [Text.Text]
 reservedExpressionOperators = [ "=", ":", "\\", "λ", "->", ",", "→", "`", "|", "(", ")", "{", ";", "}" ]
 
 reservedTypeOperators :: [Text.Text]
-reservedTypeOperators = [ ":", "=>", "⇒", "|", ",", "(", ")", ";", "{", "}", "×", "*", "Π" ]
+reservedTypeOperators = [ ":", "|", ",", "(", ")", ";", "{", "}", "×", "*", "Π" ]

--- a/src/Nihil/TypeChecking.hs
+++ b/src/Nihil/TypeChecking.hs
@@ -53,7 +53,12 @@ defaultGlobalEnv = GlobalEnv (Env defaultTypeCtx) (Env defaultCustomTypes) (Env 
             , ("List",    KStar `kArr` KStar)
             , ("()",      KStar)
             , ("->",      KStar `kArr` KStar `kArr` KStar)
-            , ("→",       KStar `kArr` KStar `kArr` KStar) ]
+            , ("→",       KStar `kArr` KStar `kArr` KStar)
+            , ("=>",      KConstraint `kArr` KStar `kArr` KStar)
+            , ("⇒",       KConstraint `kArr` KStar `kArr` KStar)
+            , ("~",       KStar `kArr` KStar `kArr` KConstraint)
+            , ("∼",       KStar `kArr` KStar `kArr` KConstraint)
+            ]
 
         defaultCustomTypes :: Map.Map String CustomType
         defaultCustomTypes = Map.fromList
@@ -73,6 +78,10 @@ defaultGlobalEnv = GlobalEnv (Env defaultTypeCtx) (Env defaultCustomTypes) (Env 
             , ("Char", locate (Forall [] (TypeAlias (locate (TPrim "Char") dummyPos))) dummyPos)
             , ("->", locate (Forall [] (TypeAlias (locate (TPrim "->") dummyPos))) dummyPos)
             , ("→", locate (Forall [] (TypeAlias (locate (TPrim "->") dummyPos))) dummyPos)
+            , ("=>", locate (Forall [] (TypeAlias (locate (TPrim "=>") dummyPos))) dummyPos)
+            , ("⇒", locate (Forall [] (TypeAlias (locate (TPrim "=>") dummyPos))) dummyPos)
+            , ("~", locate (Forall [] (TypeAlias (locate (TPrimC "~") dummyPos))) dummyPos)
+            , ("∼", locate (Forall [] (TypeAlias (locate (TPrimC "~") dummyPos))) dummyPos)
             ]
 
         defaultConstructors :: Map.Map String (Scheme Type)

--- a/src/Nihil/TypeChecking/Core.hs
+++ b/src/Nihil/TypeChecking/Core.hs
@@ -23,6 +23,7 @@ data Kind
     | KApplication Kind Kind  -- ^ > { k₁ k₂ }
     | KArrow                  -- ^ > { -> } or { → }
     | KRow                    -- ^ A special kind for row types
+    | KConstraint             -- ^ A special kind for type constraints
   deriving
     ( -- | Use only for debugging
       Show
@@ -46,7 +47,8 @@ data Type'
     | TRigid String           -- ^ > { a }
     | TTuple [Type]           -- ^ > { (a, b, c) }
     | TApplication Type Type  -- ^ > { t₁ t₂ }
-    | TPrim String
+    | TPrim String            -- ^ Primitive type
+    | TPrimC String           -- ^ Primitive constraint
     | TRow (Map.Map String Type) (Maybe Type)
                               -- ^ > { f : t1 ; g : t2 | rest }
     | TRecord Type            -- ^ > { { f : t1 ; g : t2 | rest } }

--- a/src/Nihil/TypeChecking/Pretty.hs
+++ b/src/Nihil/TypeChecking/Pretty.hs
@@ -18,6 +18,7 @@ instance Pretty Kind where
             prettyᵏ k@KApplication{}           = parens (pretty k)
             prettyᵏ k                          = pretty k
     pretty KRow                 = text "Row"
+    pretty KConstraint          = text "Constraint"
 
 instance Pretty Type' where
     pretty (TId i)              = text i -- if isOperator i then parens (text i) else text i
@@ -31,6 +32,7 @@ instance Pretty Type' where
                     _                    -> parens (pretty t)
             prettyᵗ t                = pretty t
     pretty (TPrim ty)           = text ty
+    pretty (TPrimC ty)          = text ty
     pretty (TRecord row)        = text "×" <> pretty row
     pretty (TRow ss ty)      =
         braces (mconcat (punctuate semi (prettyStts ss)) <+> text "|" <+> maybe (text "{}") pretty ty)

--- a/src/Nihil/TypeChecking/Rules/Inference/Kind.hs
+++ b/src/Nihil/TypeChecking/Rules/Inference/Kind.hs
@@ -47,6 +47,7 @@ inferKind = annotated >>> f
             tell [k1 :*~ kArr k2 kv]
             pure kv
         f (TPrim _) = pure KStar
+        f (TPrimC _) = pure KConstraint
         f (TRecord row)        = KStar <$ inferKind row
         f (TRow stts Nothing)  = do
             traverse_ (inferKind >=> \k -> tell [KStar :*~ k]) stts


### PR DESCRIPTION
Constraints were absolutely needed to develop records.
For example, the type of `proj` is:
```hs
proj : (r1 :< r2) => ×{| r2} -> ×{| r1}
```

<br>

I might improve constraints later by making them kind polymorphic.
`~` should, in fact, have type: 
```hs
(~) : forall k. k -> k -> Constraint
```
to allow it to accept both types and rows.

`,` also could have type:
```hs
(,) : forall k. k -> k -> k
```
to allow it being used as the left-hand side type of `=>`. 